### PR TITLE
Add Support for Zone Data Sources, including Route53

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 config.json
+__pycache__

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DNS Certificate Checker
 ## Overview
-DNS Certertifcate Checker is a tool designed to scan _all_ TLS enabled services under a given DNS zone. By sourcing information from A and CNAME records directly from authoritative DNS servers, it can check a given IP address for all hostnames that it should serve, according to information sourced from the DNS server(s).
+DNS Certificate Checker is a tool designed to scan _all_ TLS enabled services under a given DNS zone. By sourcing information from A and CNAME records directly from authoritative Data Stores (only BIND DNS servers at this time), it can check a given IP address for all hostnames that it should serve, according to information sourced from the DNS server(s).
 
 ## Requirements
 * python >= 3.7
@@ -10,12 +10,14 @@ DNS Certertifcate Checker is a tool designed to scan _all_ TLS enabled services 
 ` python3 -m pip install -r requirements.txt`
 
 ## Usage
-Once a valid configuration file present at `config.json` (see `config.json.example` for inspiration), the next step is to get exports of the DNS zones to be scanned. If the same host will be used to fetch zone transfers and scan for TLS services, `dns_cert_checker.py` can be invoked on its own. Else, if a seperate host is used for exporting DNS zone transfers, `fetch_zone_transfers.py` should be invoked on the approved host, and the resulting JSON file should be supplied to the execution of `dns_cert_checker.py` via the `--from-zones-json` argument.
+Once a valid configuration file present at `config.json` (see `config.json.example` for inspiration), the next step is to get exports of the DNS zones to be scanned. If the same host will be used to fetch zone transfers and scan for TLS services, `dns_cert_checker.py` can be invoked on its own. Else, if a separate host is used for exporting DNS zone transfers, `fetch_zone_transfers.py` should be invoked on the approved host, and the resulting JSON file should be supplied to the execution of `dns_cert_checker.py` via the `--from-zones-json` argument.
 
 ## Considerations
-By default, this program will request zone transfers for each provided zone for a given name server. The host running this program must have its IP address approved to request zone transfers from all configured nameservers. **This privilege should not be taken lightly**. Although zone transfers are extremely useful in this context, they're also a fantastic resource for any attackers that can communicate with the DNS server. Be vigilant in your DNS server configuration, and [keep a lean list of hosts approved to request zone transfers](https://docs.microsoft.com/en-us/services-hub/health/remediation-steps-ad/configure-all-dns-zones-only-to-allow-zone-transfers-to-specified-ip-addresses).
+If using a bind Zone Data Source, this program will request zone transfers for each provided zone for the configured name server. The host running this program must have its IP address approved to request zone transfers from all configured nameservers. **This privilege should not be taken lightly**. Although zone transfers are extremely useful in this context, they're also a fantastic resource for any attackers that can communicate with the DNS server. Be vigilant in your DNS server configuration, and [keep a lean list of hosts approved to request zone transfers](https://docs.microsoft.com/en-us/services-hub/health/remediation-steps-ad/configure-all-dns-zones-only-to-allow-zone-transfers-to-specified-ip-addresses).
 
-If you'd rather not perform a zone transfer at run-time, the accompanying script `fetch_zone_transfers.py` can be used to generate a  JSON  listing of zone records, readable by DNS Certificate Checker with the `--from-zones-json` command-line argument.
+Other Zone Data Sources may carry other considerations, such as credential management for cloud-based DNS services.
+
+If you'd rather not fetch DNS zone contents at run-time, the accompanying script `fetch_zone_transfers.py` can be used to generate a  JSON  listing of zone records, readable by DNS Certificate Checker with the `--from-zones-json` command-line argument.
 
 Wildcard DNS records are not conclusively evaluated, as they can provide an infinite number of certificates, depending on the host's configuration. At this time, DNS Certificate Checker simply checks against the `*` subdomain of a given wildcard record. Note that this will be fine if the wildcard target simply serves a wildcard certificate for the (sub)domain.
 
@@ -24,7 +26,7 @@ Wildcard DNS records are not conclusively evaluated, as they can provide an infi
 |short name|long name|help text|
 |-|-|-|
 |`-o`|`--output_csv`|If set, output a CSV of all detected certificate warnings/errors that were discovered
-|N/A|`--from-zones-json`|If set, load zone information from the provided JSON file instead of requesting zone transfers from nameservers at runtime
+|N/A|`--from-zones-json`|If set, load zone information from the provided JSON file instead of requesting zone transfers from zone data sources at runtime
 
 ### `fetch_zone_transfers.py`
 |short name|long name|help text|
@@ -39,7 +41,7 @@ A sample configuration file is present at `config.json.example`.
 |`log_level`|The level to use in the logger's call to `setLevel`|int|30 (logging.WARNING)|
 |`ssl_ports`|A list of ports to check when scanning hosts|List[int]|[443]|
 |`min_time_to_expiration`|The minimum number of seconds of certificate validity to not consider it close to expiration|int|2592000 (30 days)|
-|`nameserver_zones`|A dict of DNS `{server: [zone_0, zone_1, ..., zone_n]}` items, where `server` is the IP address of an authoritative DNS server for all zones below it|Dict[str, List[str]]|N/A|
+|`zone_data_sources`|A dict of Zone Data Sources, with keys being human-readable identifiers (not parsed by the program), and the values being Zone Data Source configurations|Dict[str, Dict]|N/A|
 |`lookup_nameservers`|If specified, a list of nameservers to use, rather than the operating system's default configuration|Optional[List[str]]|N/A|
 
 ## SSLyze Tunables

--- a/config.json.example
+++ b/config.json.example
@@ -4,14 +4,30 @@
         443
     ],
     "min_time_to_expiration": 2592000,
-    "nameserver_zones": {
-        "10.0.0.2": [
-            "company.com",
-            "internal_domain.lan"
-        ],
-        "10.0.0.3": [
-            "company-community.org"
-        ]
+    "zone_data_sources": {
+        "main_dns_server": {
+            "type": "BIND",
+            "config": {
+                "server_ip": "10.0.0.2",
+                "server_port": 53
+            },
+            "zones": [
+                "company.com",
+                "internal_domain.lan"
+            ],
+            "discover_zones": true
+        },
+        "secodary_dns_server": {
+            "type": "BIND",
+            "config": {
+                "server_ip": "10.0.0.3",
+                "server_port": 53
+            },
+            "zones": [
+                "company-community.org"
+            ],
+            "discover_zones": true
+        }
     },
     "lookup_nameservers": [
         "10.0.0.2",
@@ -19,6 +35,6 @@
         "8.8.8.8"
     ],
     "name_filters": [
-		"user.*.com"
-	]
+        "user.*.com"
+    ]
 }

--- a/config.json.example
+++ b/config.json.example
@@ -15,7 +15,7 @@
                 "company.com",
                 "internal_domain.lan"
             ],
-            "discover_zones": true
+            "discover_zones": false
         },
         "secodary_dns_server": {
             "type": "BIND",
@@ -25,6 +25,19 @@
             },
             "zones": [
                 "company-community.org"
+            ],
+            "discover_zones": false
+        },
+        "route53_instance":{
+            "type": "Route53",
+            "config": {
+                "aws_access_key_id": "",
+                "aws_secret_access_key": "",
+                "aws_session_token": "",
+                "discover_private_zones": true
+            },
+            "zones": [
+                "route53-hosted.com"
             ],
             "discover_zones": true
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+boto3
 dnspython
 sslyze>=5.0,<6.0

--- a/zone_data_source/__init__.py
+++ b/zone_data_source/__init__.py
@@ -1,0 +1,33 @@
+# This file is part of DNS Certificate Checker.
+#
+# Copyright Datto, Inc.
+# Author: Scott Conway <sconway@datto.com>
+#
+# Licensed under the Mozilla Public License Version 2.0
+# Fedora-License-Identifier: MPLv2.0
+# SPDX-2.0-License-Identifier: MPL-2.0
+# SPDX-3.0-License-Identifier: MPL-2.0
+#
+# DNS Certificate Checker is free software.
+# For more information on the license, see LICENSE.
+# For more information on free software,
+# see <https://www.gnu.org/philosophy/free-sw.en.html>.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at <https://mozilla.org/MPL/2.0/>.
+
+import os
+
+from .zone_data_source import ZoneDataSource
+from .bind import BindZoneDataSource
+
+name_to_class = {
+    "BIND": BindZoneDataSource
+}
+
+pkg_dir = os.path.dirname(os.path.abspath(__file__))
+
+__all__ = [
+    fname[:-3] for fname in os.listdir(pkg_dir)
+]

--- a/zone_data_source/__init__.py
+++ b/zone_data_source/__init__.py
@@ -21,9 +21,11 @@ import os
 
 from .zone_data_source import ZoneDataSource
 from .bind import BindZoneDataSource
+from .route53 import Route53ZoneDataSource
 
 name_to_class = {
-    "BIND": BindZoneDataSource
+    "BIND": BindZoneDataSource,
+    "Route53": Route53ZoneDataSource
 }
 
 pkg_dir = os.path.dirname(os.path.abspath(__file__))

--- a/zone_data_source/bind.py
+++ b/zone_data_source/bind.py
@@ -1,0 +1,82 @@
+# This file is part of DNS Certificate Checker.
+#
+# Copyright Datto, Inc.
+# Author: Scott Conway <sconway@datto.com>
+#
+# Licensed under the Mozilla Public License Version 2.0
+# Fedora-License-Identifier: MPLv2.0
+# SPDX-2.0-License-Identifier: MPL-2.0
+# SPDX-3.0-License-Identifier: MPL-2.0
+#
+# DNS Certificate Checker is free software.
+# For more information on the license, see LICENSE.
+# For more information on free software,
+# see <https://www.gnu.org/philosophy/free-sw.en.html>.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at <https://mozilla.org/MPL/2.0/>.
+
+from typing import Dict, List, Optional, Set
+
+import dns.resolver
+
+from .zone_data_source import ZoneDataSource
+
+
+class BindZoneDataSource(ZoneDataSource):
+    def __init__(
+        self,
+        config: Dict,
+        zones: Optional[List[str]] = None,
+        discover_zones: Optional[bool] = False,
+    ):
+
+        super(BindZoneDataSource, self).__init__(config, zones, discover_zones)
+        self.server_ip = config["server_ip"]
+        self.server_port = config.get("server_port", 53)
+        self.DNS_RECORD_TYPES = ["A", "CNAME"]
+
+    def get_all_zones(self) -> Set[str]:
+        """
+        If discover_zones is True, return all zones seen
+        under this datasource.
+        Else, return only the zones provided by
+        the configuration's `zone` list.
+
+        :return: A list of zones provided by this ZoneDataSource
+        :rtype: Set[str]
+        """
+
+        # Since BIND servers can't tell you what zones they serve,
+        # we can only know what we know
+        return self.zones
+
+    def get_zone_contents(self, zone: str) -> List[Dict]:
+        """
+        Returns the contents of a zone as a list of DNS records dicts
+
+        :param zone: The zone name whose records to fetch (eg. example.com)
+        :type zone: str
+        :return: A list of DNS records under the given zone
+        :rtype: List[Dict]
+        """
+
+        zone_records = list()
+
+        zone_xfr_results = dns.zone.from_xfr(
+            dns.query.xfr(self.server_ip, zone, port=self.server_port)
+        )
+
+        for record_type in self.DNS_RECORD_TYPES:
+            for n, ttl, data in zone_xfr_results.iterate_rdatas(record_type):
+                zone_records.append(
+                    {
+                        "type": record_type,
+                        "name": str(n),
+                        "ttl": ttl,
+                        "target": str(data),
+                    }
+                )
+
+        return zone_records

--- a/zone_data_source/bind.py
+++ b/zone_data_source/bind.py
@@ -19,7 +19,9 @@
 
 from typing import Dict, List, Optional, Set
 
+import dns.query
 import dns.resolver
+import dns.zone
 
 from .zone_data_source import ZoneDataSource
 

--- a/zone_data_source/route53.py
+++ b/zone_data_source/route53.py
@@ -1,0 +1,179 @@
+# This file is part of DNS Certificate Checker.
+#
+# Copyright Datto, Inc.
+# Author: Scott Conway <sconway@datto.com>
+#
+# Licensed under the Mozilla Public License Version 2.0
+# Fedora-License-Identifier: MPLv2.0
+# SPDX-2.0-License-Identifier: MPL-2.0
+# SPDX-3.0-License-Identifier: MPL-2.0
+#
+# DNS Certificate Checker is free software.
+# For more information on the license, see LICENSE.
+# For more information on free software,
+# see <https://www.gnu.org/philosophy/free-sw.en.html>.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at <https://mozilla.org/MPL/2.0/>.
+
+from collections import defaultdict
+from typing import Dict, List, Optional, Set
+
+import boto3
+import dns
+
+from .zone_data_source import ZoneDataSource
+
+
+class Route53ZoneDataSource(ZoneDataSource):
+    def __init__(
+        self,
+        config: Dict,
+        zones: Optional[List[str]] = None,
+        discover_zones: Optional[bool] = False,
+    ):
+
+        self.DNS_RECORD_TYPES = ["A", "CNAME"]
+        self.discover_private_zones = config.get("discover_private_zones", False)
+
+        # set up the boto client before calling super's init
+        self.boto_client = boto3.client(
+            "route53",
+            aws_access_key_id=config["aws_access_key_id"],
+            aws_secret_access_key=config["aws_secret_access_key"],
+            aws_session_token=config["aws_session_token"],
+        )
+
+        # TODO check if our client can view zones/records!
+
+        # now get a mapping of zone names to their ResourceIds
+        self.zone_name_to_resource_ids = defaultdict(lambda: list())
+
+        hosted_zone_paginator = self.boto_client.get_paginator("list_hosted_zones")
+        for page in hosted_zone_paginator.paginate():
+            page_zones = page["HostedZones"]
+            for zone in page_zones:
+                self.zone_name_to_resource_ids[zone["Name"][:-1]].append(
+                    zone["Id"].split("/")[-1]
+                )
+
+        super(Route53ZoneDataSource, self).__init__(config, zones, discover_zones)
+
+    def normalize_record_name(self, resource_record_name: str, zone_name: str) -> str:
+        """
+        Given a resource record name from Route53,
+        reformat it to a "BIND-comatible" name.
+
+        It performs the following modifications:
+            * truncate the trailing period
+            * truncate the zone name from the end of record[Name]
+            * replace \\052 with * (for wildcards)
+            * replace an entry to just the zone name with "@"
+
+        :param resource_record_name: The "Name" attribute of a resource record
+        :type resource_record_name: str
+        :param zone_name: The resource record's DNS zone, as a string
+        :type zone_name: str
+        :return: A bind-compatible "name" attribute for this resource record
+        :rtype: str
+        """
+
+        return (
+            resource_record_name[:-1]
+            .replace("\\052", "*")
+            .replace("." + zone_name, "")
+            .replace(zone_name, "@")
+        )
+
+    def get_all_zones(self) -> Set[str]:
+        """
+        If discover_zones is True, return all zones seen
+        under this datasource.
+        Else, return only the zones provided by
+        the configuration's `zone` list.
+
+        :return: A list of zones provided by this ZoneDataSource
+        :rtype: Set[str]
+        """
+
+        discovered_zones = set()
+        hosted_zone_paginator = self.boto_client.get_paginator("list_hosted_zones")
+        for page in hosted_zone_paginator.paginate():
+            page_zones = page["HostedZones"]
+            for zone in page_zones:
+
+                # skip private zones by default
+                if zone["Config"]["PrivateZone"] and not self.discover_private_zones:
+                    continue
+
+                discovered_zones.add(zone["Name"][:-1])  # truncate last period
+
+        return self.zones | discovered_zones
+
+    def get_zone_contents(self, zone: str) -> List[Dict]:
+        """
+        Returns the contents of a zone as a list of DNS records dicts
+
+        :param zone: The zone name whose records to fetch (eg. example.com)
+        :type zone: str
+        :return: A list of DNS records under the given zone
+        :rtype: List[Dict]
+        """
+
+        zone_records = list()
+
+        # a given zone might be under multiple ResourceIds
+        zone_ids = self.zone_name_to_resource_ids.get(zone, None)
+
+        if zone_ids is None:
+            raise Exception(f'Invalid ZoneId "{zone}"')
+
+        for zone_id in zone_ids:
+            zone_resource_record_paginator = self.boto_client.get_paginator(
+                "list_resource_record_sets"
+            )
+
+            for page in zone_resource_record_paginator.paginate(HostedZoneId=zone_id):
+                for resource_record in page["ResourceRecordSets"]:
+
+                    if resource_record["Type"] not in self.DNS_RECORD_TYPES:
+                        continue
+
+                    # not all records have a "ResourceRecords" section
+                    for target in resource_record.get("ResourceRecords", list()):
+                        zone_records.append(
+                            {
+                                "type": resource_record["Type"],
+                                "name": self.normalize_record_name(
+                                    resource_record["Name"], zone
+                                ),
+                                "ttl": resource_record["TTL"],
+                                "target": target["Value"],
+                            }
+                        )
+
+                    alias_target = resource_record.get("AliasTarget", None)
+                    if alias_target is not None:
+                        # Route53 offers dynamic records through aliases,
+                        # which makes getting a BIND-compatible zone representation
+                        # kinda difficult.
+                        #
+                        # We see that this record exists, and will now ask an
+                        # external nameserver about what it says about this record
+                        dns_res = dns.resolver.resolve(
+                            resource_record["Name"], resource_record["Type"]
+                        )
+                        for entry in dns_res:
+                            zone_records.append(
+                                {
+                                    "type": resource_record["Type"],
+                                    "name": self.normalize_record_name(
+                                        resource_record["Name"], zone
+                                    ),
+                                    "ttl": None,  # TODO can we get this value?
+                                    "target": entry.address,
+                                }
+                            )
+
+        return zone_records

--- a/zone_data_source/zone_data_source.py
+++ b/zone_data_source/zone_data_source.py
@@ -1,0 +1,72 @@
+# This file is part of DNS Certificate Checker.
+#
+# Copyright Datto, Inc.
+# Author: Scott Conway <sconway@datto.com>
+#
+# Licensed under the Mozilla Public License Version 2.0
+# Fedora-License-Identifier: MPLv2.0
+# SPDX-2.0-License-Identifier: MPL-2.0
+# SPDX-3.0-License-Identifier: MPL-2.0
+#
+# DNS Certificate Checker is free software.
+# For more information on the license, see LICENSE.
+# For more information on free software,
+# see <https://www.gnu.org/philosophy/free-sw.en.html>.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at <https://mozilla.org/MPL/2.0/>.
+
+from typing import Dict, List, Optional, Set
+
+
+class ZoneDataSource:
+    def __init__(self, config: Dict, zones: Optional[List[str]] = None, discover_zones: Optional[bool] = False):
+        if zones is None:
+            self.zones = set()
+        else:
+            self.zones = set(zones)
+
+        if discover_zones:
+            self.zones |= self.get_all_zones()
+
+    def get_all_zones(self) -> Set[str]:
+        """
+
+        If discover_zones is True, return all zones seen
+        under this datasource.
+        Else, return only the zones provided by
+        the configuration's `zone` list.
+
+        :return: A list of zones provided by this ZoneDataSource
+        :rtype: Set[str]
+        """
+
+        raise NotImplementedError()
+
+    def get_zone_contents(self, zone: str) -> List[Dict]:
+        """
+        Returns the contents of a zone as a list of DNS records dicts
+
+        :return: A list of DNS records under the given zone
+        :rtype: List[Dict]
+        """
+
+        raise NotImplementedError()
+
+    def get_all_zone_contents(self) -> Dict[str, List[Dict]]:
+        """
+        Returns a dict of {zone_name: [zone_result_0, ..., zone_result_n]}
+        items for each zone in self.zones
+
+        :return: A mapping of each zone to the zone's records,
+            as determined by this ZoneDataSource.
+        :rtype: Dict[str, List[Dict]]
+        """
+
+        res = dict()
+
+        for zone in self.zones:
+            res[zone] = self.get_zone_contents(zone)
+
+        return res


### PR DESCRIPTION
These changes make it so that dns-cert-checker can source (BIND-compatible) zone records from data sources besides just BIND itself.

At this time, BindZoneDataSource and Route53ZoneDataSource are the only implemented sources.

Zone Data Sources may have the capability to "discover zones". BIND cannot do this, but Route53 can, as the console will tell you which HostedZones exist.